### PR TITLE
fix(hassio): correct image path format for HA addon

### DIFF
--- a/.github/workflows/addon-build.yaml
+++ b/.github/workflows/addon-build.yaml
@@ -12,7 +12,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -93,15 +92,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch,suffix=-${{ matrix.arch }}
-            type=semver,pattern={{version}},suffix=-${{ matrix.arch }}
-            type=sha,suffix=-${{ matrix.arch }}
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          else
+            echo "version=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -110,7 +108,8 @@ jobs:
           file: snmp-mqtt-bridge/Dockerfile
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/spdg/snmp-mqtt-bridge/${{ matrix.arch }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/spdg/snmp-mqtt-bridge/${{ matrix.arch }}:latest
           build-args: |
             BUILD_ARCH=${{ matrix.arch }}

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.2"
+version: "0.0.4"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Problem
HA addon failed to install because image path format was wrong.

Config.yaml specifies: `ghcr.io/spdg/snmp-mqtt-bridge/{arch}`
But CI was pushing: `ghcr.io/spdg/snmp-mqtt-bridge:version-{arch}`

## Fix
- Push images as `ghcr.io/spdg/snmp-mqtt-bridge/{arch}:version`
- This matches HA's expected `{arch}` substitution pattern
- Bump addon version to 0.0.4