### PR TITLE
fix(ci): auto-publish packages as public

### DIFF
--- a/.github/workflows/addon-build.yaml
+++ b/.github/workflows/addon-build.yaml
@@ -111,5 +111,31 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/spdg/snmp-mqtt-bridge/${{ matrix.arch }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/spdg/snmp-mqtt-bridge/${{ matrix.arch }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/SPDG/snmp-mqtt-bridge
+            org.opencontainers.image.description=SNMP-MQTT Bridge Home Assistant Addon (${{ matrix.arch }})
+            org.opencontainers.image.licenses=MIT
           build-args: |
             BUILD_ARCH=${{ matrix.arch }}
+
+  # Make packages public after build
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      packages: write
+
+    steps:
+      - name: Make packages public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for arch in amd64 aarch64 armv7 armhf i386; do
+            echo "Setting visibility for snmp-mqtt-bridge/${arch}..."
+            gh api \
+              --method PATCH \
+              -H "Accept: application/vnd.github+json" \
+              /orgs/SPDG/packages/container/snmp-mqtt-bridge%2F${arch}/visibility \
+              -f visibility='public' || echo "Failed for ${arch} (may need manual action)"
+          done

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.4"
+version: "0.0.5"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Problem
GitHub Container Registry packages are private by default, causing HA addon install to fail with unauthorized error.

## Fix
- Add `publish` job that runs after all builds complete
- Uses GitHub API to set package visibility to public
- Add proper OCI labels (`org.opencontainers.image.source`) to link packages to repo
- Bump addon version to 0.0.5

Note: The API call may fail due to GITHUB_TOKEN permissions. If so, packages need to be made public manually once via GitHub UI.