### PR TITLE
fix(frontend): use relative paths for HA Ingress compatibility

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -19,4 +19,5 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
+  base: './',  // Use relative paths for HA Ingress compatibility
 })

--- a/internal/embed/frontend/index.html
+++ b/internal/embed/frontend/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SNMP-MQTT Bridge</title>
-    <script type="module" crossorigin src="/assets/index-MpFOtVKH.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CRiwnXhg.css">
+    <script type="module" crossorigin src="./assets/index-MpFOtVKH.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-CRiwnXhg.css">
   </head>
   <body class="bg-gray-100">
     <div id="app"></div>

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.6"
+version: "0.0.7"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Problem
Assets (JS, CSS) return 404 when accessed via HA Ingress because paths were absolute (`/assets/...`).

## Fix
Set Vite `base: './'` to generate relative paths (`./assets/...`).

Before: `<script src="/assets/index.js">`
After: `<script src="./assets/index.js">`