### PR TITLE
Fix PostgreSQL DSN port formatting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,13 +33,13 @@ type DatabaseConfig struct {
 }
 
 type MQTTConfig struct {
-	Broker       string `mapstructure:"broker"`
-	Port         int    `mapstructure:"port"`
-	Username     string `mapstructure:"username"`
-	Password     string `mapstructure:"password"`
-	ClientID     string `mapstructure:"client_id"`
-	TopicPrefix  string `mapstructure:"topic_prefix"`
-	Discovery    bool   `mapstructure:"discovery"`
+	Broker          string `mapstructure:"broker"`
+	Port            int    `mapstructure:"port"`
+	Username        string `mapstructure:"username"`
+	Password        string `mapstructure:"password"`
+	ClientID        string `mapstructure:"client_id"`
+	TopicPrefix     string `mapstructure:"topic_prefix"`
+	Discovery       bool   `mapstructure:"discovery"`
 	DiscoveryPrefix string `mapstructure:"discovery_prefix"`
 }
 
@@ -128,5 +129,5 @@ func (c *DatabaseConfig) GetDSN() string {
 	if c.DSN != "" {
 		return c.DSN
 	}
-	return "host=" + c.Host + " port=" + string(rune(c.Port)) + " user=" + c.User + " password=" + c.Password + " dbname=" + c.DBName + " sslmode=disable"
+	return "host=" + c.Host + " port=" + strconv.Itoa(c.Port) + " user=" + c.User + " password=" + c.Password + " dbname=" + c.DBName + " sslmode=disable"
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestDatabaseConfigGetDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  DatabaseConfig
+		want string
+	}{
+		{
+			name: "sqlite returns configured dsn",
+			cfg: DatabaseConfig{
+				Driver: "sqlite",
+				DSN:    "./data/snmp-bridge.db",
+			},
+			want: "./data/snmp-bridge.db",
+		},
+		{
+			name: "postgres returns explicit dsn",
+			cfg: DatabaseConfig{
+				Driver: "postgres",
+				DSN:    "postgres://snmp_bridge:secret@localhost:5432/snmp_bridge?sslmode=disable",
+			},
+			want: "postgres://snmp_bridge:secret@localhost:5432/snmp_bridge?sslmode=disable",
+		},
+		{
+			name: "postgres builds dsn with decimal port",
+			cfg: DatabaseConfig{
+				Driver:   "postgres",
+				Host:     "localhost",
+				Port:     5432,
+				User:     "snmp_bridge",
+				Password: "secret",
+				DBName:   "snmp_bridge",
+			},
+			want: "host=localhost port=5432 user=snmp_bridge password=secret dbname=snmp_bridge sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.GetDSN(); got != tt.want {
+				t.Fatalf("GetDSN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- format generated PostgreSQL DSN ports with `strconv.Itoa` instead of rune conversion
- add regression coverage for sqlite, explicit DSN, and structured PostgreSQL config

## Tests
- `go test ./...`
- `git diff --check`

Closes #13