### PR TITLE
Fix WebSocket concurrent writes and client map races

### DIFF
--- a/internal/api/handler/websocket.go
+++ b/internal/api/handler/websocket.go
@@ -13,6 +13,14 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+const (
+	wsWriteWait      = 10 * time.Second
+	wsPongWait       = 60 * time.Second
+	wsPingPeriod     = 30 * time.Second
+	wsMaxMessageSize = 512
+	wsSendBufferSize = 256
+)
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -21,10 +29,20 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+type wsMessage struct {
+	messageType int
+	data        []byte
+}
+
+type wsClient struct {
+	conn *websocket.Conn
+	send chan wsMessage
+}
+
 // WebSocketHandler handles WebSocket connections for real-time updates
 type WebSocketHandler struct {
 	pollerService *service.PollerService
-	clients       map[*websocket.Conn]bool
+	clients       map[*wsClient]bool
 	mu            sync.RWMutex
 	broadcast     chan []byte
 }
@@ -33,7 +51,7 @@ type WebSocketHandler struct {
 func NewWebSocketHandler(pollerService *service.PollerService) *WebSocketHandler {
 	h := &WebSocketHandler{
 		pollerService: pollerService,
-		clients:       make(map[*websocket.Conn]bool),
+		clients:       make(map[*wsClient]bool),
 		broadcast:     make(chan []byte, 256),
 	}
 
@@ -56,34 +74,77 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 		return
 	}
 
-	h.mu.Lock()
-	h.clients[conn] = true
-	h.mu.Unlock()
+	client := &wsClient{
+		conn: conn,
+		send: make(chan wsMessage, wsSendBufferSize),
+	}
+
+	h.registerClient(client)
+	go h.writePump(client)
 
 	// Send initial state
-	h.sendInitialState(conn)
+	h.sendInitialState(client)
 
 	// Handle incoming messages
-	go h.handleClient(conn)
+	h.readPump(client)
 }
 
-func (h *WebSocketHandler) handleClient(conn *websocket.Conn) {
-	defer func() {
-		h.mu.Lock()
-		delete(h.clients, conn)
-		h.mu.Unlock()
+func (h *WebSocketHandler) registerClient(client *wsClient) {
+	h.mu.Lock()
+	h.clients[client] = true
+	h.mu.Unlock()
+}
+
+func (h *WebSocketHandler) unregisterClient(client *wsClient) {
+	var conn *websocket.Conn
+
+	h.mu.Lock()
+	if _, ok := h.clients[client]; ok {
+		delete(h.clients, client)
+		close(client.send)
+		conn = client.conn
+	}
+	h.mu.Unlock()
+
+	if conn != nil {
 		conn.Close()
+	}
+}
+
+func (h *WebSocketHandler) enqueue(client *wsClient, message wsMessage) bool {
+	h.mu.RLock()
+	_, ok := h.clients[client]
+	if !ok {
+		h.mu.RUnlock()
+		return false
+	}
+
+	select {
+	case client.send <- message:
+		h.mu.RUnlock()
+		return true
+	default:
+		h.mu.RUnlock()
+		h.unregisterClient(client)
+		return false
+	}
+}
+
+func (h *WebSocketHandler) readPump(client *wsClient) {
+	defer func() {
+		h.unregisterClient(client)
+		client.conn.Close()
 	}()
 
-	conn.SetReadLimit(512)
-	conn.SetReadDeadline(time.Now().Add(60 * time.Second))
-	conn.SetPongHandler(func(string) error {
-		conn.SetReadDeadline(time.Now().Add(60 * time.Second))
+	client.conn.SetReadLimit(wsMaxMessageSize)
+	client.conn.SetReadDeadline(time.Now().Add(wsPongWait))
+	client.conn.SetPongHandler(func(string) error {
+		client.conn.SetReadDeadline(time.Now().Add(wsPongWait))
 		return nil
 	})
 
 	for {
-		_, message, err := conn.ReadMessage()
+		_, message, err := client.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				log.Printf("WebSocket error: %v", err)
@@ -92,13 +153,43 @@ func (h *WebSocketHandler) handleClient(conn *websocket.Conn) {
 		}
 
 		// Handle incoming messages (e.g., subscribe to specific devices)
-		h.handleMessage(conn, message)
+		h.handleMessage(client, message)
 	}
 }
 
-func (h *WebSocketHandler) handleMessage(conn *websocket.Conn, message []byte) {
+func (h *WebSocketHandler) writePump(client *wsClient) {
+	ticker := time.NewTicker(wsPingPeriod)
+	defer func() {
+		ticker.Stop()
+		h.unregisterClient(client)
+		client.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-client.send:
+			client.conn.SetWriteDeadline(time.Now().Add(wsWriteWait))
+			if !ok {
+				client.conn.WriteMessage(websocket.CloseMessage, nil)
+				return
+			}
+
+			if err := client.conn.WriteMessage(message.messageType, message.data); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			client.conn.SetWriteDeadline(time.Now().Add(wsWriteWait))
+			if err := client.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (h *WebSocketHandler) handleMessage(client *wsClient, message []byte) {
 	var msg struct {
-		Type string `json:"type"`
+		Type string          `json:"type"`
 		Data json.RawMessage `json:"data"`
 	}
 
@@ -109,14 +200,17 @@ func (h *WebSocketHandler) handleMessage(conn *websocket.Conn, message []byte) {
 	switch msg.Type {
 	case "ping":
 		response := map[string]string{"type": "pong"}
-		data, _ := json.Marshal(response)
-		conn.WriteMessage(websocket.TextMessage, data)
+		data, err := json.Marshal(response)
+		if err != nil {
+			return
+		}
+		h.enqueue(client, wsMessage{messageType: websocket.TextMessage, data: data})
 	case "subscribe":
 		// Handle subscription to specific device updates
 	}
 }
 
-func (h *WebSocketHandler) sendInitialState(conn *websocket.Conn) {
+func (h *WebSocketHandler) sendInitialState(client *wsClient) {
 	if h.pollerService == nil {
 		return
 	}
@@ -132,36 +226,25 @@ func (h *WebSocketHandler) sendInitialState(conn *websocket.Conn) {
 		return
 	}
 
-	conn.WriteMessage(websocket.TextMessage, data)
+	h.enqueue(client, wsMessage{messageType: websocket.TextMessage, data: data})
 }
 
 func (h *WebSocketHandler) handleBroadcasts() {
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
+	for message := range h.broadcast {
+		h.broadcastToClients(message)
+	}
+}
 
-	for {
-		select {
-		case message := <-h.broadcast:
-			h.mu.RLock()
-			for client := range h.clients {
-				if err := client.WriteMessage(websocket.TextMessage, message); err != nil {
-					client.Close()
-					delete(h.clients, client)
-				}
-			}
-			h.mu.RUnlock()
+func (h *WebSocketHandler) broadcastToClients(message []byte) {
+	h.mu.RLock()
+	clients := make([]*wsClient, 0, len(h.clients))
+	for client := range h.clients {
+		clients = append(clients, client)
+	}
+	h.mu.RUnlock()
 
-		case <-ticker.C:
-			// Send ping to all clients
-			h.mu.RLock()
-			for client := range h.clients {
-				if err := client.WriteMessage(websocket.PingMessage, nil); err != nil {
-					client.Close()
-					delete(h.clients, client)
-				}
-			}
-			h.mu.RUnlock()
-		}
+	for _, client := range clients {
+		h.enqueue(client, wsMessage{messageType: websocket.TextMessage, data: message})
 	}
 }
 

--- a/internal/api/handler/websocket_test.go
+++ b/internal/api/handler/websocket_test.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func newTestWebSocketHandler() *WebSocketHandler {
+	return &WebSocketHandler{
+		clients:   make(map[*wsClient]bool),
+		broadcast: make(chan []byte, 1),
+	}
+}
+
+func TestWebSocketHandlerUnregisterClosesClientSendOnce(t *testing.T) {
+	h := newTestWebSocketHandler()
+	client := &wsClient{send: make(chan wsMessage, 1)}
+
+	h.registerClient(client)
+	h.unregisterClient(client)
+	h.unregisterClient(client)
+
+	if _, ok := h.clients[client]; ok {
+		t.Fatal("client still registered after unregister")
+	}
+
+	if _, ok := <-client.send; ok {
+		t.Fatal("client send channel is still open after unregister")
+	}
+}
+
+func TestWebSocketHandlerBroadcastRemovesFullClient(t *testing.T) {
+	h := newTestWebSocketHandler()
+	fullClient := &wsClient{send: make(chan wsMessage, 1)}
+	readyClient := &wsClient{send: make(chan wsMessage, 1)}
+
+	fullClient.send <- wsMessage{messageType: websocket.TextMessage, data: []byte("queued")}
+	h.registerClient(fullClient)
+	h.registerClient(readyClient)
+
+	h.broadcastToClients([]byte("update"))
+
+	if _, ok := h.clients[fullClient]; ok {
+		t.Fatal("full client still registered after failed enqueue")
+	}
+	if _, ok := h.clients[readyClient]; !ok {
+		t.Fatal("ready client was unexpectedly unregistered")
+	}
+
+	message := <-readyClient.send
+	if message.messageType != websocket.TextMessage || string(message.data) != "update" {
+		t.Fatalf("ready client received %+v, want text update", message)
+	}
+
+	if _, ok := <-fullClient.send; !ok {
+		t.Fatal("expected queued message before closed channel")
+	}
+	if _, ok := <-fullClient.send; ok {
+		t.Fatal("full client send channel is still open")
+	}
+}
+
+func TestWebSocketHandlerPingQueuesPong(t *testing.T) {
+	h := newTestWebSocketHandler()
+	client := &wsClient{send: make(chan wsMessage, 1)}
+	h.registerClient(client)
+
+	h.handleMessage(client, []byte(`{"type":"ping"}`))
+
+	message := <-client.send
+	if message.messageType != websocket.TextMessage {
+		t.Fatalf("message type = %d, want %d", message.messageType, websocket.TextMessage)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(message.data, &payload); err != nil {
+		t.Fatalf("failed to unmarshal pong payload: %v", err)
+	}
+	if payload["type"] != "pong" {
+		t.Fatalf("payload type = %q, want pong", payload["type"])
+	}
+}


### PR DESCRIPTION
## Summary
- replace direct WebSocket writes with a per-client outbound queue and writer goroutine
- move client registration/removal behind exclusive locking
- keep broadcasts and application pongs on the serialized write path
- add handler tests for unregister, full-client removal, and ping/pong queuing

## Tests
- `go test ./...`
- `go test -race ./internal/api/handler`
- `git diff --check`

Closes #14