### PR TITLE
Fix ATEN outlet control settings

### DIFF
--- a/frontend/src/views/DeviceDetail.vue
+++ b/frontend/src/views/DeviceDetail.vue
@@ -26,6 +26,7 @@ const form = ref({
   ip_address: '',
   port: 161,
   community: 'public',
+  write_community: '',
   snmp_version: 'v2c',
   profile_id: '',
   poll_interval: 0,
@@ -42,6 +43,10 @@ const isATS = computed(() => {
 
 const isPDU = computed(() => {
   return profile.value?.category === 'pdu'
+})
+
+const isAtenPDU = computed(() => {
+  return isPDU.value && (device.value?.profile_id?.startsWith('aten') || profile.value?.manufacturer === 'ATEN')
 })
 
 function toNumber(value) {
@@ -126,7 +131,7 @@ const outlets = computed(() => {
       delete pendingOutletStates.value[i]
     }
 
-    const isOn = stateVal === 'On' || stateVal === 1
+    const isOn = stateVal === 'On' || stateVal === 1 || stateVal === 2
     result.push({
       number: i,
       name,
@@ -277,7 +282,7 @@ async function toggleOutlet(outlet) {
       timestamp: Date.now()
     }
     // Wait briefly for poll to confirm the change
-    await waitForOutletState(outlet.number, expectedState, 3000)
+    await waitForOutletState(outlet.number, expectedState, 10000)
   } catch (e) {
     // Clear pending state on error
     delete pendingOutletStates.value[outlet.number]
@@ -293,7 +298,8 @@ async function waitForOutletState(outletNum, expectedState, timeoutMs) {
   while (Date.now() - startTime < timeoutMs) {
     await new Promise(r => setTimeout(r, 300))
     const currentState = state.value?.values?.[`Outlet ${outletNum} State`]
-    if (currentState === expectedState || currentState === (expectedState === 'On' ? 1 : 0)) {
+    const numericExpectedState = expectedState === 'On' ? 2 : 1
+    if (currentState === expectedState || currentState === numericExpectedState) {
       // State confirmed - clear pending state
       delete pendingOutletStates.value[outletNum]
       return true
@@ -321,10 +327,26 @@ function startEditOutletName(outlet) {
   newOutletName.value = outlet.name
 }
 
+function validateOutletName(name) {
+  if (!name) return 'Outlet name cannot be empty'
+
+  if (isAtenPDU.value && !/^[A-Za-z0-9_ ]{1,48}$/.test(name)) {
+    return 'ATEN outlet names can use only letters, numbers, spaces, and underscores, up to 48 characters.'
+  }
+
+  return null
+}
+
 async function saveOutletName() {
   if (!editingOutletName.value || !newOutletName.value.trim()) return
   const outletNum = editingOutletName.value
   const expectedName = newOutletName.value.trim()
+  const validationError = validateOutletName(expectedName)
+  if (validationError) {
+    alert(validationError)
+    return
+  }
+
   outletLoading.value[outletNum] = true
   try {
     await api.setOutletName(device.value.id, outletNum, expectedName)
@@ -364,6 +386,7 @@ function openEditModal() {
     ip_address: device.value.ip_address,
     port: device.value.port,
     community: device.value.community,
+    write_community: device.value.write_community || '',
     snmp_version: device.value.snmp_version,
     profile_id: device.value.profile_id || '',
     poll_interval: device.value.poll_interval || 0,
@@ -607,8 +630,10 @@ function getValueByMapping(mapping) {
                 <template v-if="editingOutletName === outlet.number">
                   <input v-model="newOutletName"
                          class="input w-full text-sm"
+                         :maxlength="isAtenPDU ? 48 : undefined"
                          @keyup.enter="saveOutletName"
                          @keyup.escape="cancelEditOutletName" />
+                  <p v-if="isAtenPDU" class="text-xs text-gray-500 dark:text-dracula-comment mt-1">ATEN: letters, numbers, spaces, underscores, max 48 characters.</p>
                   <div class="flex gap-2 mt-1">
                     <button @click="saveOutletName" class="text-green-600 dark:text-dracula-green hover:text-green-800 text-xs">Save</button>
                     <button @click="cancelEditOutletName" class="text-gray-600 dark:text-dracula-fg hover:text-gray-800 text-xs">Cancel</button>
@@ -804,6 +829,11 @@ function getValueByMapping(mapping) {
               <label class="label">{{ form.snmp_version === 'v3' ? 'Username' : 'Community' }}</label>
               <input v-model="form.community" class="input" :placeholder="form.snmp_version === 'v3' ? 'snmpuser' : 'public'" />
               <p v-if="form.snmp_version === 'v3'" class="text-xs text-gray-500 mt-1">noAuthNoPriv mode</p>
+            </div>
+            <div v-if="form.snmp_version !== 'v3'">
+              <label class="label">Write Community (optional)</label>
+              <input v-model="form.write_community" class="input" placeholder="private" />
+              <p class="text-xs text-gray-500 mt-1">Used for SNMP SET commands (outlet control, rename). Leave empty to use read community.</p>
             </div>
             <div>
               <label class="label">SNMP Version</label>

--- a/frontend/src/views/DeviceDetail.vue
+++ b/frontend/src/views/DeviceDetail.vue
@@ -49,6 +49,29 @@ const isAtenPDU = computed(() => {
   return isPDU.value && (device.value?.profile_id?.startsWith('aten') || profile.value?.manufacturer === 'ATEN')
 })
 
+const isEnergeniePDU = computed(() => {
+  return isPDU.value && (device.value?.profile_id?.startsWith('energenie') || profile.value?.manufacturer === 'Energenie')
+})
+
+function isExpectedOutletState(currentState, expectedState) {
+  if (typeof currentState === 'string' && currentState.toLowerCase() === expectedState.toLowerCase()) {
+    return true
+  }
+
+  if (isAtenPDU.value) {
+    const numericExpectedState = expectedState === 'On' ? 2 : 1
+    return currentState === numericExpectedState || currentState === String(numericExpectedState)
+  }
+
+  if (isEnergeniePDU.value) {
+    const numericExpectedState = expectedState === 'On' ? 1 : 0
+    return currentState === numericExpectedState || currentState === String(numericExpectedState)
+  }
+
+  const numericExpectedState = expectedState === 'On' ? 1 : 2
+  return currentState === numericExpectedState || currentState === String(numericExpectedState)
+}
+
 function toNumber(value) {
   if (value === null || value === undefined || value === '') return null
   const parsed = parseFloat(value)
@@ -131,7 +154,7 @@ const outlets = computed(() => {
       delete pendingOutletStates.value[i]
     }
 
-    const isOn = stateVal === 'On' || stateVal === 1 || stateVal === 2
+    const isOn = isExpectedOutletState(stateVal, 'On')
     result.push({
       number: i,
       name,
@@ -298,8 +321,7 @@ async function waitForOutletState(outletNum, expectedState, timeoutMs) {
   while (Date.now() - startTime < timeoutMs) {
     await new Promise(r => setTimeout(r, 300))
     const currentState = state.value?.values?.[`Outlet ${outletNum} State`]
-    const numericExpectedState = expectedState === 'On' ? 2 : 1
-    if (currentState === expectedState || currentState === numericExpectedState) {
+    if (isExpectedOutletState(currentState, expectedState)) {
       // State confirmed - clear pending state
       delete pendingOutletStates.value[outletNum]
       return true

--- a/internal/api/handler/command.go
+++ b/internal/api/handler/command.go
@@ -246,6 +246,21 @@ type SetOutletNameRequest struct {
 	Name   string `json:"name" binding:"required"`
 }
 
+func validateAtenOutletName(name string) error {
+	if name == "" || len(name) > 48 {
+		return fmt.Errorf("ATEN outlet name must be 1-48 characters")
+	}
+
+	for _, ch := range name {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == ' ' || ch == '_' {
+			continue
+		}
+		return fmt.Errorf("ATEN outlet name may contain only letters, numbers, spaces, and underscores")
+	}
+
+	return nil
+}
+
 // SetOutletName sets the name of a PDU outlet
 func (h *CommandHandler) SetOutletName(c *gin.Context) {
 	deviceID := c.Param("id")
@@ -257,6 +272,11 @@ func (h *CommandHandler) SetOutletName(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		RespondBadRequest(c, "Outlet name cannot be empty")
+		return
+	}
 
 	// Look up device to get its profile
 	device, err := h.deviceService.GetByID(ctx, deviceID)
@@ -275,6 +295,10 @@ func (h *CommandHandler) SetOutletName(c *gin.Context) {
 		nameOID = fmt.Sprintf(".1.3.6.1.4.1.17420.1.2.9.%d.14.1.0", req.Outlet)
 		value = fmt.Sprintf("%s,0,0,0,0", req.Name)
 	} else if strings.HasPrefix(device.ProfileID, "aten") {
+		if err := validateAtenOutletName(req.Name); err != nil {
+			RespondBadRequest(c, err.Error())
+			return
+		}
 		// ATEN PE series outlet name table.
 		nameOID = fmt.Sprintf(".1.3.6.1.4.1.21317.1.3.2.2.2.2.10.1.2.%d", req.Outlet)
 		value = req.Name

--- a/internal/api/handler/command_test.go
+++ b/internal/api/handler/command_test.go
@@ -1,0 +1,27 @@
+package handler
+
+import "testing"
+
+func TestValidateAtenOutletName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "hive 07"},
+		{name: "hive_07"},
+		{name: "UPPER lower 123"},
+		{name: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+		{name: "", wantErr: true},
+		{name: "hive-07", wantErr: true},
+		{name: "hive.07", wantErr: true},
+		{name: "zażółć", wantErr: true},
+		{name: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		err := validateAtenOutletName(tt.name)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("validateAtenOutletName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+}

--- a/internal/service/snmp.go
+++ b/internal/service/snmp.go
@@ -64,9 +64,12 @@ func (s *SNMPService) SetValue(ctx context.Context, deviceID, oid string, value 
 		return fmt.Errorf("unsupported value type: %T", value)
 	}
 
-	_, err = client.Set([]gosnmp.SnmpPDU{pdu})
+	packet, err := client.Set([]gosnmp.SnmpPDU{pdu})
 	if err != nil {
 		return fmt.Errorf("SNMP SET failed: %w", err)
+	}
+	if packet != nil && packet.Error != gosnmp.NoError {
+		return fmt.Errorf("SNMP SET rejected: %s at index %d", packet.Error, packet.ErrorIndex)
 	}
 
 	return nil

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.9"
+version: "0.0.10"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Summary
- add Write Community to the device detail edit modal
- validate ATEN outlet names before SNMP SET: 1-48 chars, letters/numbers/spaces/underscores only
- return backend errors when SNMP SET responds with BadValue/WrongLength
- handle ATEN numeric outlet state values and wait longer for pending state
- bump Home Assistant addon version to 0.0.10

## ATEN PE8108G validation
Tested live on outlet 4 at 192.168.26.205 using write community `private`. The PDU accepts names like `hive 07`, `hive_07`, and 48-character ASCII names. It rejects `hive-07` with `BadValue`, rejects punctuation and non-ASCII with `BadValue`, and rejects 49+ chars with `WrongLength`. Outlet 4 was restored to `Outlet 4` after probing.

## Tests
- `npm run build`
- `go test ./...`
- `git diff --check`