### PR TITLE
Fix SNMP-level error handling in MQTT publisher command handler

### DIFF
--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -452,9 +452,12 @@ func (p *Publisher) sendSNMPSet(device *domain.Device, oid string, value interfa
 		return fmt.Errorf("unsupported value type: %T", value)
 	}
 
-	_, err := client.Set([]gosnmp.SnmpPDU{pdu})
+	packet, err := client.Set([]gosnmp.SnmpPDU{pdu})
 	if err != nil {
 		return fmt.Errorf("SNMP SET failed: %w", err)
+	}
+	if packet != nil && packet.Error != gosnmp.NoError {
+		return fmt.Errorf("SNMP SET rejected: %s at index %d", packet.Error, packet.ErrorIndex)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
This PR fixes #20: **MQTT Publisher command handler ignores SNMP-level SET errors**.

Previously, the MQTT command handler (`sendSNMPSet` in `internal/mqtt/publisher.go`) only checked for Go-level errors returned by `client.Set()`. However, SNMP-level rejections (e.g. `BadValue`, `WrongLength` error codes returned by the agent inside the packet response) do not trigger Go-level errors. This caused the publisher to assume success, log success, and notify Home Assistant of a state change even when the target device rejected the command.

## Changes
- Updated `sendSNMPSet` in `internal/mqtt/publisher.go` to capture the returned `gosnmp.SnmpPacket` from `client.Set()`.
- Added a check to verify that `packet.Error == gosnmp.NoError`, identical to the fix already implemented in `internal/service/snmp.go` for the HTTP API command handler.

## Testing
- Verified compilation and ran the test suite: `go test ./...`
