### PR TITLE
Match SNMP traps to hostname devices

### DIFF
--- a/internal/worker/trap_receiver.go
+++ b/internal/worker/trap_receiver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -93,17 +94,12 @@ func (r *TrapReceiver) Stop() {
 func (r *TrapReceiver) handleTrap(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 	log.Printf("Received trap from %s", addr.IP.String())
 
-	// Find device by IP
+	// Find device by source IP. Devices may be configured by hostname, so resolve
+	// hostnames before deciding the trap is unrelated.
 	var deviceID *string
 	devices, err := r.deviceRepo.GetAll(context.Background())
 	if err == nil {
-		for _, d := range devices {
-			if d.IPAddress == addr.IP.String() {
-				id := d.ID
-				deviceID = &id
-				break
-			}
-		}
+		deviceID = findDeviceIDByTrapSource(devices, addr.IP, lookupHost)
 	}
 
 	// Parse trap OID
@@ -146,15 +142,71 @@ func (r *TrapReceiver) handleTrap(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) 
 
 	// Trigger immediate poll for the device if known
 	if deviceID != nil && r.poller != nil {
-		// The poller will update state on next poll cycle
-		// For immediate update, we could add a TriggerPoll method to PollerService
-		log.Printf("Trap received for device %s, will be reflected in next poll", *deviceID)
+		r.poller.TriggerPoll(*deviceID)
+		log.Printf("Trap received for device %s, triggered immediate poll", *deviceID)
 	}
 
 	// Notify handlers
 	if r.onTrap != nil {
 		r.onTrap(trapLog)
 	}
+}
+
+type hostLookupFunc func(string) ([]string, error)
+
+func lookupHost(host string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	return net.DefaultResolver.LookupHost(ctx, host)
+}
+
+func findDeviceIDByTrapSource(devices []domain.Device, sourceIP net.IP, lookupHost hostLookupFunc) *string {
+	if sourceIP == nil {
+		return nil
+	}
+
+	incomingIP := sourceIP.String()
+	for _, device := range devices {
+		if matchDeviceAddress(device.IPAddress, incomingIP, lookupHost) {
+			id := device.ID
+			return &id
+		}
+	}
+
+	return nil
+}
+
+func matchDeviceAddress(deviceAddress, incomingIP string, lookupHost hostLookupFunc) bool {
+	deviceAddress = strings.TrimSpace(deviceAddress)
+	incomingIP = strings.TrimSpace(incomingIP)
+	if deviceAddress == "" || incomingIP == "" {
+		return false
+	}
+	if deviceAddress == incomingIP {
+		return true
+	}
+
+	incoming := net.ParseIP(incomingIP)
+	if incoming == nil {
+		return false
+	}
+
+	if configuredIP := net.ParseIP(deviceAddress); configuredIP != nil {
+		return configuredIP.Equal(incoming)
+	}
+
+	resolvedIPs, err := lookupHost(deviceAddress)
+	if err != nil {
+		return false
+	}
+	for _, resolvedIP := range resolvedIPs {
+		if parsed := net.ParseIP(resolvedIP); parsed != nil && parsed.Equal(incoming) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (r *TrapReceiver) parseVariable(variable gosnmp.SnmpPDU) interface{} {

--- a/internal/worker/trap_receiver_test.go
+++ b/internal/worker/trap_receiver_test.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"snmp-mqtt-bridge/internal/domain"
+)
+
+func TestFindDeviceIDByTrapSource(t *testing.T) {
+	devices := []domain.Device{
+		{ID: "ups-1", IPAddress: "ups.local"},
+		{ID: "pdu-1", IPAddress: "192.168.1.50"},
+		{ID: "pdu-2", IPAddress: "pdu-rack1.lan"},
+		{ID: "ups-v6", IPAddress: "ups-v6.local"},
+	}
+
+	lookup := func(host string) ([]string, error) {
+		switch host {
+		case "ups.local":
+			return []string{"192.168.1.10"}, nil
+		case "pdu-rack1.lan":
+			return []string{"192.168.1.100", "10.0.0.10"}, nil
+		case "ups-v6.local":
+			return []string{"2001:db8::10"}, nil
+		default:
+			return nil, errors.New("not found")
+		}
+	}
+
+	tests := []struct {
+		name     string
+		sourceIP string
+		wantID   string
+	}{
+		{name: "matches literal IPv4", sourceIP: "192.168.1.50", wantID: "pdu-1"},
+		{name: "matches resolved hostname", sourceIP: "192.168.1.100", wantID: "pdu-2"},
+		{name: "matches resolved IPv6 hostname", sourceIP: "2001:db8::10", wantID: "ups-v6"},
+		{name: "returns nil for unknown source", sourceIP: "192.168.1.200"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findDeviceIDByTrapSource(devices, net.ParseIP(tt.sourceIP), lookup)
+			if tt.wantID == "" {
+				if got != nil {
+					t.Fatalf("findDeviceIDByTrapSource() = %q, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != tt.wantID {
+				var gotID string
+				if got != nil {
+					gotID = *got
+				}
+				t.Fatalf("findDeviceIDByTrapSource() = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestMatchDeviceAddressDoesNotResolveLiteralIP(t *testing.T) {
+	called := false
+	lookup := func(string) ([]string, error) {
+		called = true
+		return nil, errors.New("unexpected lookup")
+	}
+
+	if !matchDeviceAddress("192.168.1.50", "192.168.1.50", lookup) {
+		t.Fatal("matchDeviceAddress() = false, want true")
+	}
+	if called {
+		t.Fatal("matchDeviceAddress resolved a literal IP address")
+	}
+}
+
+func TestMatchDeviceAddressReturnsFalseOnLookupError(t *testing.T) {
+	lookup := func(string) ([]string, error) {
+		return nil, errors.New("not found")
+	}
+
+	if matchDeviceAddress("missing.local", "192.168.1.50", lookup) {
+		t.Fatal("matchDeviceAddress() = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- resolve hostname-configured devices when matching incoming trap source IPs
- add a bounded DNS lookup for trap matching to avoid long resolver stalls
- trigger an immediate poll when a trap is matched to a known device
- add unit tests for literal IP, hostname, IPv6, and lookup-error matching paths

Fixes #21.

## Tests
- `go test ./...`
- `git diff --check`