### PR TITLE
Fix MQTT discovery sync on device lifecycle changes

### DIFF
--- a/cmd/snmp-bridge/main.go
+++ b/cmd/snmp-bridge/main.go
@@ -88,6 +88,7 @@ func main() {
 		Poller:     pollerService,
 		SNMP:       snmpService,
 		MQTTClient: mqttClient,
+		Publisher:  publisher,
 	}
 
 	server := api.NewServer(cfg, services, embedfs.FrontendFS)

--- a/internal/api/handler/device.go
+++ b/internal/api/handler/device.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log"
 	"net/http"
 
 	"snmp-mqtt-bridge/internal/domain"
@@ -13,13 +14,21 @@ import (
 type DeviceHandler struct {
 	deviceService *service.DeviceService
 	pollerService *service.PollerService
+	publisher     DevicePublisher
+}
+
+// DevicePublisher keeps MQTT discovery and command subscriptions in sync with device CRUD.
+type DevicePublisher interface {
+	RegisterDevice(device *domain.Device) error
+	UnregisterDevice(deviceID string) error
 }
 
 // NewDeviceHandler creates a new device handler
-func NewDeviceHandler(deviceService *service.DeviceService, pollerService *service.PollerService) *DeviceHandler {
+func NewDeviceHandler(deviceService *service.DeviceService, pollerService *service.PollerService, publisher DevicePublisher) *DeviceHandler {
 	return &DeviceHandler{
 		deviceService: deviceService,
 		pollerService: pollerService,
+		publisher:     publisher,
 	}
 }
 
@@ -65,6 +74,7 @@ func (h *DeviceHandler) Create(c *gin.Context) {
 	if h.pollerService != nil && device.Enabled {
 		h.pollerService.AddDevice(device)
 	}
+	h.registerDevice(device)
 
 	RespondCreated(c, device)
 }
@@ -79,6 +89,12 @@ func (h *DeviceHandler) Update(c *gin.Context) {
 		return
 	}
 
+	previousDevice, err := h.deviceService.GetByID(c.Request.Context(), id)
+	if err != nil {
+		RespondNotFound(c, "Device not found")
+		return
+	}
+
 	device, err := h.deviceService.Update(c.Request.Context(), id, &req)
 	if err != nil {
 		RespondNotFound(c, "Device not found")
@@ -89,6 +105,7 @@ func (h *DeviceHandler) Update(c *gin.Context) {
 	if h.pollerService != nil {
 		h.pollerService.UpdateDevice(device)
 	}
+	h.refreshDeviceRegistration(previousDevice, device)
 
 	RespondOK(c, device)
 }
@@ -106,8 +123,37 @@ func (h *DeviceHandler) Delete(c *gin.Context) {
 	if h.pollerService != nil {
 		h.pollerService.RemoveDevice(id)
 	}
+	h.unregisterDevice(id)
 
 	c.JSON(http.StatusNoContent, nil)
+}
+
+func (h *DeviceHandler) registerDevice(device *domain.Device) {
+	if h.publisher == nil || !device.Enabled {
+		return
+	}
+	if err := h.publisher.RegisterDevice(device); err != nil {
+		log.Printf("Failed to register device %s with MQTT: %v", device.ID, err)
+	}
+}
+
+func (h *DeviceHandler) refreshDeviceRegistration(previousDevice, device *domain.Device) {
+	if h.publisher == nil {
+		return
+	}
+	if previousDevice != nil && previousDevice.Enabled {
+		h.unregisterDevice(previousDevice.ID)
+	}
+	h.registerDevice(device)
+}
+
+func (h *DeviceHandler) unregisterDevice(deviceID string) {
+	if h.publisher == nil {
+		return
+	}
+	if err := h.publisher.UnregisterDevice(deviceID); err != nil {
+		log.Printf("Failed to unregister device %s from MQTT: %v", deviceID, err)
+	}
 }
 
 // TestConnection tests SNMP connection to an existing device

--- a/internal/api/handler/device_test.go
+++ b/internal/api/handler/device_test.go
@@ -1,0 +1,260 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"snmp-mqtt-bridge/internal/domain"
+	"snmp-mqtt-bridge/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestDeviceHandler_CreateRegistersEnabledDevice(t *testing.T) {
+	repo := newFakeDeviceRepo()
+	publisher := &fakeDevicePublisher{}
+	handler := NewDeviceHandler(service.NewDeviceService(repo), nil, publisher)
+
+	w := performDeviceRequest(http.MethodPost, "/devices", "/devices", handler.Create, map[string]interface{}{
+		"name":         "New ATS",
+		"ip_address":   "192.168.26.50",
+		"community":    "private",
+		"snmp_version": "v2c",
+		"profile_id":   "apc-ats",
+		"enabled":      true,
+	})
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+	if len(publisher.registered) != 1 {
+		t.Fatalf("expected one MQTT registration, got %d", len(publisher.registered))
+	}
+	if publisher.registered[0].Name != "New ATS" {
+		t.Fatalf("expected registered device name New ATS, got %q", publisher.registered[0].Name)
+	}
+}
+
+func TestDeviceHandler_CreateDoesNotRegisterDisabledDevice(t *testing.T) {
+	repo := newFakeDeviceRepo()
+	publisher := &fakeDevicePublisher{}
+	handler := NewDeviceHandler(service.NewDeviceService(repo), nil, publisher)
+
+	w := performDeviceRequest(http.MethodPost, "/devices", "/devices", handler.Create, map[string]interface{}{
+		"name":         "Disabled ATS",
+		"ip_address":   "192.168.26.51",
+		"community":    "private",
+		"snmp_version": "v2c",
+		"profile_id":   "apc-ats",
+		"enabled":      false,
+	})
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, w.Code, w.Body.String())
+	}
+	if len(publisher.registered) != 0 {
+		t.Fatalf("expected no MQTT registrations, got %d", len(publisher.registered))
+	}
+}
+
+func TestDeviceHandler_UpdateRefreshesEnabledDeviceRegistration(t *testing.T) {
+	repo := newFakeDeviceRepo()
+	repo.devices["dev1"] = &domain.Device{
+		ID:          "dev1",
+		Name:        "Old ATS",
+		IPAddress:   "192.168.26.52",
+		Port:        161,
+		Community:   "private",
+		SNMPVersion: domain.SNMPv2c,
+		ProfileID:   "apc-ats",
+		Enabled:     true,
+	}
+	publisher := &fakeDevicePublisher{}
+	handler := NewDeviceHandler(service.NewDeviceService(repo), nil, publisher)
+
+	w := performDeviceRequest(http.MethodPut, "/devices/:id", "/devices/dev1", handler.Update, map[string]interface{}{
+		"name": "Renamed ATS",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	if len(publisher.unregistered) != 1 || publisher.unregistered[0] != "dev1" {
+		t.Fatalf("expected dev1 MQTT unregistration, got %#v", publisher.unregistered)
+	}
+	if len(publisher.registered) != 1 {
+		t.Fatalf("expected one refreshed MQTT registration, got %d", len(publisher.registered))
+	}
+	if publisher.registered[0].Name != "Renamed ATS" {
+		t.Fatalf("expected refreshed device name Renamed ATS, got %q", publisher.registered[0].Name)
+	}
+}
+
+func TestDeviceHandler_UpdateUnregistersDisabledDevice(t *testing.T) {
+	repo := newFakeDeviceRepo()
+	repo.devices["dev1"] = &domain.Device{
+		ID:          "dev1",
+		Name:        "ATS",
+		IPAddress:   "192.168.26.53",
+		Port:        161,
+		Community:   "private",
+		SNMPVersion: domain.SNMPv2c,
+		ProfileID:   "apc-ats",
+		Enabled:     true,
+	}
+	publisher := &fakeDevicePublisher{}
+	handler := NewDeviceHandler(service.NewDeviceService(repo), nil, publisher)
+
+	w := performDeviceRequest(http.MethodPut, "/devices/:id", "/devices/dev1", handler.Update, map[string]interface{}{
+		"enabled": false,
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+	if len(publisher.unregistered) != 1 || publisher.unregistered[0] != "dev1" {
+		t.Fatalf("expected dev1 MQTT unregistration, got %#v", publisher.unregistered)
+	}
+	if len(publisher.registered) != 0 {
+		t.Fatalf("expected no refreshed MQTT registration, got %d", len(publisher.registered))
+	}
+}
+
+func TestDeviceHandler_DeleteUnregistersDevice(t *testing.T) {
+	repo := newFakeDeviceRepo()
+	repo.devices["dev1"] = &domain.Device{
+		ID:          "dev1",
+		Name:        "ATS",
+		IPAddress:   "192.168.26.54",
+		Port:        161,
+		Community:   "private",
+		SNMPVersion: domain.SNMPv2c,
+		ProfileID:   "apc-ats",
+		Enabled:     true,
+	}
+	publisher := &fakeDevicePublisher{}
+	handler := NewDeviceHandler(service.NewDeviceService(repo), nil, publisher)
+
+	w := performDeviceRequest(http.MethodDelete, "/devices/:id", "/devices/dev1", handler.Delete, nil)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNoContent, w.Code, w.Body.String())
+	}
+	if len(publisher.unregistered) != 1 || publisher.unregistered[0] != "dev1" {
+		t.Fatalf("expected dev1 MQTT unregistration, got %#v", publisher.unregistered)
+	}
+}
+
+func performDeviceRequest(method, routePath, requestPath string, handlerFunc gin.HandlerFunc, body interface{}) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Handle(method, routePath, handlerFunc)
+
+	var requestBody bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&requestBody).Encode(body)
+	}
+
+	req := httptest.NewRequest(method, requestPath, &requestBody)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+type fakeDevicePublisher struct {
+	registered   []*domain.Device
+	unregistered []string
+}
+
+func (p *fakeDevicePublisher) RegisterDevice(device *domain.Device) error {
+	copied := *device
+	p.registered = append(p.registered, &copied)
+	return nil
+}
+
+func (p *fakeDevicePublisher) UnregisterDevice(deviceID string) error {
+	p.unregistered = append(p.unregistered, deviceID)
+	return nil
+}
+
+type fakeDeviceRepo struct {
+	devices map[string]*domain.Device
+}
+
+func newFakeDeviceRepo() *fakeDeviceRepo {
+	return &fakeDeviceRepo{devices: make(map[string]*domain.Device)}
+}
+
+func (r *fakeDeviceRepo) Create(_ context.Context, device *domain.Device) error {
+	copied := *device
+	r.devices[device.ID] = &copied
+	return nil
+}
+
+func (r *fakeDeviceRepo) GetByID(_ context.Context, id string) (*domain.Device, error) {
+	device, ok := r.devices[id]
+	if !ok {
+		return nil, errFakeNotFound
+	}
+	copied := *device
+	return &copied, nil
+}
+
+func (r *fakeDeviceRepo) GetAll(_ context.Context) ([]domain.Device, error) {
+	devices := make([]domain.Device, 0, len(r.devices))
+	for _, device := range r.devices {
+		devices = append(devices, *device)
+	}
+	return devices, nil
+}
+
+func (r *fakeDeviceRepo) GetEnabled(_ context.Context) ([]domain.Device, error) {
+	devices := make([]domain.Device, 0)
+	for _, device := range r.devices {
+		if device.Enabled {
+			devices = append(devices, *device)
+		}
+	}
+	return devices, nil
+}
+
+func (r *fakeDeviceRepo) Update(_ context.Context, device *domain.Device) error {
+	if _, ok := r.devices[device.ID]; !ok {
+		return errFakeNotFound
+	}
+	copied := *device
+	r.devices[device.ID] = &copied
+	return nil
+}
+
+func (r *fakeDeviceRepo) Delete(_ context.Context, id string) error {
+	if _, ok := r.devices[id]; !ok {
+		return errFakeNotFound
+	}
+	delete(r.devices, id)
+	return nil
+}
+
+func (r *fakeDeviceRepo) UpdateLastSeen(_ context.Context, id string) error {
+	device, ok := r.devices[id]
+	if !ok {
+		return errFakeNotFound
+	}
+	now := time.Now()
+	device.LastSeen = &now
+	return nil
+}
+
+var errFakeNotFound = &fakeNotFoundError{}
+
+type fakeNotFoundError struct{}
+
+func (e *fakeNotFoundError) Error() string {
+	return "not found"
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -35,6 +35,7 @@ type Services struct {
 	Poller     *service.PollerService
 	SNMP       *service.SNMPService
 	MQTTClient *mqtt.Client
+	Publisher  *mqtt.Publisher
 }
 
 // NewServer creates a new HTTP server
@@ -65,7 +66,7 @@ func (s *Server) setupRoutes(frontendFS embed.FS) {
 	api := s.router.Group("/api")
 	{
 		// Devices
-		deviceHandler := handler.NewDeviceHandler(s.services.Device, s.services.Poller)
+		deviceHandler := handler.NewDeviceHandler(s.services.Device, s.services.Poller, s.services.Publisher)
 		devices := api.Group("/devices")
 		{
 			devices.GET("", deviceHandler.List)


### PR DESCRIPTION
## Summary
- wire the MQTT publisher into device create/update/delete flows
- register discovery and command subscriptions immediately for newly enabled devices
- refresh discovery on updates and unregister discovery/subscriptions on disable or delete
- add handler-level tests for MQTT lifecycle sync

Closes #12.

## HA observation
While checking the live Home Assistant instance, the addon update entity reports installed_version=0.0.10 and latest_version=0.0.10. The GitHub release/tag v0.0.12 exists, but `snmp-mqtt-bridge/config.yaml` at that tag still has `version: "0.0.10"`, so HA does not see v0.0.12 as an addon update.

## Tests
- go test ./...
