### PR TITLE
Bump Home Assistant addon version to 0.0.13

### DIFF
--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.10"
+version: "0.0.13"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Summary
- bump the Home Assistant addon manifest version to 0.0.13

This is required because v0.0.12 exists as a GitHub release, but the addon manifest at that tag still reports `version: "0.0.10"`, so Home Assistant only sees 0.0.10 as the latest addon version.

## Tests
- go test ./...
- git diff --check
