### PR TITLE
Fix MQTT reconnect discovery refresh

### DIFF
--- a/cmd/snmp-bridge/main.go
+++ b/cmd/snmp-bridge/main.go
@@ -60,13 +60,16 @@ func main() {
 
 	// Create MQTT client
 	mqttClient := mqtt.NewClient(&cfg.MQTT)
+	discovery := mqtt.NewDiscovery(mqttClient, cfg.MQTT.DiscoveryPrefix, cfg.MQTT.TopicPrefix)
+	publisher := mqtt.NewPublisher(mqttClient, discovery, pollerService, profileRepo)
+	mqttClient.AddOnConnectHandler(func() {
+		if err := publisher.RefreshDiscovery(); err != nil {
+			log.Printf("Warning: Failed to refresh MQTT discovery after connect: %v", err)
+		}
+	})
 	if err := mqttClient.Connect(); err != nil {
 		log.Printf("Warning: Failed to connect to MQTT broker: %v", err)
 	}
-
-	// Create MQTT discovery and publisher
-	discovery := mqtt.NewDiscovery(mqttClient, cfg.MQTT.DiscoveryPrefix, cfg.MQTT.TopicPrefix)
-	publisher := mqtt.NewPublisher(mqttClient, discovery, pollerService, profileRepo)
 
 	// Create trap receiver
 	trapReceiver := worker.NewTrapReceiver(cfg.SNMP.TrapPort, deviceRepo, trapRepo, pollerService)

--- a/internal/api/handler/setting.go
+++ b/internal/api/handler/setting.go
@@ -19,10 +19,16 @@ type MQTTReconnector interface {
 	GetConfig() *config.MQTTConfig
 }
 
+// MQTTDiscoveryRefresher republishes MQTT discovery after reconnect/config changes.
+type MQTTDiscoveryRefresher interface {
+	RefreshDiscovery() error
+}
+
 // SettingHandler handles setting-related HTTP requests
 type SettingHandler struct {
 	settingService *service.SettingService
 	mqttClient     MQTTReconnector
+	mqttDiscovery  MQTTDiscoveryRefresher
 	appCfg         *config.Config
 }
 
@@ -37,6 +43,11 @@ func NewSettingHandler(settingService *service.SettingService, appCfg *config.Co
 // SetMQTTClient sets the MQTT client for reconnection support
 func (h *SettingHandler) SetMQTTClient(client *mqtt.Client) {
 	h.mqttClient = client
+}
+
+// SetMQTTDiscoveryRefresher sets the MQTT discovery refresher used after reconnect.
+func (h *SettingHandler) SetMQTTDiscoveryRefresher(refresher MQTTDiscoveryRefresher) {
+	h.mqttDiscovery = refresher
 }
 
 // List returns all settings
@@ -167,10 +178,21 @@ func (h *SettingHandler) ReconnectMQTT(c *gin.Context) {
 		return
 	}
 
+	if h.mqttDiscovery != nil {
+		if err := h.mqttDiscovery.RefreshDiscovery(); err != nil {
+			RespondOK(c, gin.H{
+				"success":   false,
+				"connected": h.mqttClient.IsConnected(),
+				"message":   "MQTT reconnected but discovery refresh failed: " + err.Error(),
+			})
+			return
+		}
+	}
+
 	RespondOK(c, gin.H{
 		"success":   true,
 		"connected": h.mqttClient.IsConnected(),
-		"message":   "MQTT reconnected successfully",
+		"message":   "MQTT reconnected and discovery refreshed successfully",
 	})
 }
 
@@ -220,7 +242,7 @@ func (h *SettingHandler) TestMQTTConnection(c *gin.Context) {
 	}
 
 	testClient := mqtt.NewClient(cfg)
-	err := testClient.Connect()
+	err := testClient.ConnectOnce()
 
 	if err != nil {
 		RespondOK(c, gin.H{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -104,6 +104,9 @@ func (s *Server) setupRoutes(frontendFS embed.FS) {
 		if s.services.MQTTClient != nil {
 			settingHandler.SetMQTTClient(s.services.MQTTClient)
 		}
+		if s.services.Publisher != nil {
+			settingHandler.SetMQTTDiscoveryRefresher(s.services.Publisher)
+		}
 		settings := api.Group("/settings")
 		{
 			settings.GET("", settingHandler.List)

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -18,13 +18,14 @@ type CommandHandler func(deviceID, entityID string, payload []byte)
 
 // Client wraps the MQTT client with convenience methods
 type Client struct {
-	cfg           *config.MQTTConfig
-	client        mqtt.Client
-	connected     bool
-	mu            sync.RWMutex
-	topicPrefix   string
-	handlers      map[string]CommandHandler
-	handlersMu    sync.RWMutex
+	cfg               *config.MQTTConfig
+	client            mqtt.Client
+	connected         bool
+	mu                sync.RWMutex
+	topicPrefix       string
+	handlers          map[string]CommandHandler
+	handlersMu        sync.RWMutex
+	onConnectHandlers []func()
 }
 
 // NewClient creates a new MQTT client
@@ -38,6 +39,15 @@ func NewClient(cfg *config.MQTTConfig) *Client {
 
 // Connect establishes connection to the MQTT broker
 func (c *Client) Connect() error {
+	return c.connect(true)
+}
+
+// ConnectOnce establishes a single MQTT connection attempt without background initial retry.
+func (c *Client) ConnectOnce() error {
+	return c.connect(false)
+}
+
+func (c *Client) connect(connectRetry bool) error {
 	broker := fmt.Sprintf("tcp://%s:%d", c.cfg.Broker, c.cfg.Port)
 
 	opts := mqtt.NewClientOptions()
@@ -51,7 +61,7 @@ func (c *Client) Connect() error {
 	}
 
 	opts.SetAutoReconnect(true)
-	opts.SetConnectRetry(false) // Don't block on initial connect
+	opts.SetConnectRetry(connectRetry)
 	opts.SetConnectRetryInterval(5 * time.Second)
 	opts.SetMaxReconnectInterval(5 * time.Minute)
 
@@ -66,6 +76,7 @@ func (c *Client) Connect() error {
 
 		// Resubscribe to command topics
 		c.resubscribe()
+		c.runOnConnectHandlers()
 	})
 
 	opts.SetConnectionLostHandler(func(client mqtt.Client, err error) {
@@ -86,11 +97,40 @@ func (c *Client) Connect() error {
 	c.client = mqtt.NewClient(opts)
 
 	token := c.client.Connect()
-	if token.WaitTimeout(10*time.Second) && token.Error() != nil {
+	if !token.WaitTimeout(10 * time.Second) {
+		if connectRetry {
+			return fmt.Errorf("timed out connecting to MQTT broker; retrying in background")
+		}
+		c.client.Disconnect(0)
+		return fmt.Errorf("timed out connecting to MQTT broker")
+	}
+	if token.Error() != nil {
 		return fmt.Errorf("failed to connect to MQTT broker: %w", token.Error())
 	}
 
 	return nil
+}
+
+// AddOnConnectHandler registers a callback that runs after every successful MQTT connection.
+func (c *Client) AddOnConnectHandler(handler func()) {
+	c.mu.Lock()
+	c.onConnectHandlers = append(c.onConnectHandlers, handler)
+	connected := c.connected
+	c.mu.Unlock()
+
+	if connected {
+		go handler()
+	}
+}
+
+func (c *Client) runOnConnectHandlers() {
+	c.mu.RLock()
+	handlers := append([]func(){}, c.onConnectHandlers...)
+	c.mu.RUnlock()
+
+	for _, handler := range handlers {
+		handler()
+	}
 }
 
 // Disconnect closes the MQTT connection

--- a/internal/mqtt/discovery.go
+++ b/internal/mqtt/discovery.go
@@ -4,34 +4,35 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"snmp-mqtt-bridge/internal/domain"
 )
 
 // DiscoveryConfig represents Home Assistant MQTT discovery payload
 type DiscoveryConfig struct {
-	Name              string            `json:"name"`
-	UniqueID          string            `json:"unique_id"`
-	ObjectID          string            `json:"object_id,omitempty"`
-	StateTopic        string            `json:"state_topic,omitempty"`
-	CommandTopic      string            `json:"command_topic,omitempty"`
-	AvailabilityTopic string            `json:"availability_topic,omitempty"`
-	PayloadAvailable  string            `json:"payload_available,omitempty"`
-	PayloadNotAvailable string          `json:"payload_not_available,omitempty"`
-	Device            *DiscoveryDevice  `json:"device,omitempty"`
-	DeviceClass       string            `json:"device_class,omitempty"`
-	StateClass        string            `json:"state_class,omitempty"`
-	UnitOfMeasurement string            `json:"unit_of_measurement,omitempty"`
-	Icon              string            `json:"icon,omitempty"`
-	EntityCategory    string            `json:"entity_category,omitempty"`
-	ValueTemplate     string            `json:"value_template,omitempty"`
-	PayloadOn         string            `json:"payload_on,omitempty"`
-	PayloadOff        string            `json:"payload_off,omitempty"`
-	Options           []string          `json:"options,omitempty"`
-	Min               float64           `json:"min,omitempty"`
-	Max               float64           `json:"max,omitempty"`
-	Step              float64           `json:"step,omitempty"`
-	Extra             map[string]interface{} `json:"-"` // For any extra fields
+	Name                string                 `json:"name"`
+	UniqueID            string                 `json:"unique_id"`
+	ObjectID            string                 `json:"object_id,omitempty"`
+	StateTopic          string                 `json:"state_topic,omitempty"`
+	CommandTopic        string                 `json:"command_topic,omitempty"`
+	AvailabilityTopic   string                 `json:"availability_topic,omitempty"`
+	PayloadAvailable    string                 `json:"payload_available,omitempty"`
+	PayloadNotAvailable string                 `json:"payload_not_available,omitempty"`
+	Device              *DiscoveryDevice       `json:"device,omitempty"`
+	DeviceClass         string                 `json:"device_class,omitempty"`
+	StateClass          string                 `json:"state_class,omitempty"`
+	UnitOfMeasurement   string                 `json:"unit_of_measurement,omitempty"`
+	Icon                string                 `json:"icon,omitempty"`
+	EntityCategory      string                 `json:"entity_category,omitempty"`
+	ValueTemplate       string                 `json:"value_template,omitempty"`
+	PayloadOn           string                 `json:"payload_on,omitempty"`
+	PayloadOff          string                 `json:"payload_off,omitempty"`
+	Options             []string               `json:"options,omitempty"`
+	Min                 float64                `json:"min,omitempty"`
+	Max                 float64                `json:"max,omitempty"`
+	Step                float64                `json:"step,omitempty"`
+	Extra               map[string]interface{} `json:"-"` // For any extra fields
 }
 
 // DiscoveryDevice represents device information in discovery payload
@@ -49,6 +50,7 @@ type Discovery struct {
 	client          *Client
 	discoveryPrefix string
 	topicPrefix     string
+	mu              sync.RWMutex
 }
 
 // NewDiscovery creates a new discovery manager
@@ -60,8 +62,22 @@ func NewDiscovery(client *Client, discoveryPrefix, topicPrefix string) *Discover
 	}
 }
 
+// UpdatePrefixes updates MQTT discovery and state topic prefixes after MQTT settings change.
+func (d *Discovery) UpdatePrefixes(discoveryPrefix, topicPrefix string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.discoveryPrefix = discoveryPrefix
+	d.topicPrefix = topicPrefix
+}
+
 // PublishBridgeDiscovery publishes discovery config for the bridge itself
 func (d *Discovery) PublishBridgeDiscovery() error {
+	d.mu.RLock()
+	discoveryPrefix := d.discoveryPrefix
+	topicPrefix := d.topicPrefix
+	d.mu.RUnlock()
+
 	haDevice := &DiscoveryDevice{
 		Identifiers:  []string{"snmp_mqtt_bridge"},
 		Name:         "SNMP-MQTT Bridge",
@@ -70,22 +86,22 @@ func (d *Discovery) PublishBridgeDiscovery() error {
 		SwVersion:    "1.0.0",
 	}
 
-	availabilityTopic := fmt.Sprintf("%s/bridge/status", d.topicPrefix)
+	availabilityTopic := fmt.Sprintf("%s/bridge/status", topicPrefix)
 
 	config := &DiscoveryConfig{
-		Name:              "Bridge Status",
-		UniqueID:          "snmp_bridge_status",
-		ObjectID:          "snmp_bridge_status",
-		Device:            haDevice,
-		StateTopic:        availabilityTopic,
-		AvailabilityTopic: availabilityTopic,
-		PayloadAvailable:  "online",
+		Name:                "Bridge Status",
+		UniqueID:            "snmp_bridge_status",
+		ObjectID:            "snmp_bridge_status",
+		Device:              haDevice,
+		StateTopic:          availabilityTopic,
+		AvailabilityTopic:   availabilityTopic,
+		PayloadAvailable:    "online",
 		PayloadNotAvailable: "offline",
-		EntityCategory:    "diagnostic",
-		Icon:              "mdi:lan-connect",
+		EntityCategory:      "diagnostic",
+		Icon:                "mdi:lan-connect",
 	}
 
-	topic := fmt.Sprintf("%s/sensor/snmp_bridge/status/config", d.discoveryPrefix)
+	topic := fmt.Sprintf("%s/sensor/snmp_bridge/status/config", discoveryPrefix)
 	return d.client.Publish(topic, config, true)
 }
 
@@ -94,6 +110,10 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 	if profile == nil {
 		return nil
 	}
+	d.mu.RLock()
+	discoveryPrefix := d.discoveryPrefix
+	topicPrefix := d.topicPrefix
+	d.mu.RUnlock()
 
 	haDevice := &DiscoveryDevice{
 		Identifiers:  []string{fmt.Sprintf("snmp_bridge_%s", device.ID)},
@@ -103,7 +123,7 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 		ViaDevice:    "snmp_mqtt_bridge",
 	}
 
-	availabilityTopic := fmt.Sprintf("%s/bridge/status", d.topicPrefix)
+	availabilityTopic := fmt.Sprintf("%s/bridge/status", topicPrefix)
 
 	// Create device prefix for entity IDs using name + short ID for uniqueness
 	// e.g., "snmp_mqtt_pdu_001_a7a66242" ensures unique entity IDs even with duplicate names
@@ -120,12 +140,12 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 		objectID := fmt.Sprintf("%s_%s", devicePrefix, entityID)
 
 		config := &DiscoveryConfig{
-			Name:              mapping.Name,
-			UniqueID:          uniqueID,
-			ObjectID:          objectID,
-			Device:            haDevice,
-			AvailabilityTopic: availabilityTopic,
-			PayloadAvailable:  "online",
+			Name:                mapping.Name,
+			UniqueID:            uniqueID,
+			ObjectID:            objectID,
+			Device:              haDevice,
+			AvailabilityTopic:   availabilityTopic,
+			PayloadAvailable:    "online",
 			PayloadNotAvailable: "offline",
 		}
 
@@ -154,11 +174,11 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 		}
 
 		// Build topics based on component type
-		stateTopic := fmt.Sprintf("%s/%s/%s/state", d.topicPrefix, device.ID, entityID)
+		stateTopic := fmt.Sprintf("%s/%s/%s/state", topicPrefix, device.ID, entityID)
 		config.StateTopic = stateTopic
 
 		if mapping.Writable {
-			config.CommandTopic = fmt.Sprintf("%s/%s/%s/set", d.topicPrefix, device.ID, entityID)
+			config.CommandTopic = fmt.Sprintf("%s/%s/%s/set", topicPrefix, device.ID, entityID)
 		}
 
 		// Component-specific configuration
@@ -205,7 +225,7 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 
 		// Publish discovery config
 		topic := fmt.Sprintf("%s/%s/%s/%s/config",
-			d.discoveryPrefix,
+			discoveryPrefix,
 			componentToString(mapping.HAComponent),
 			device.ID,
 			entityID,
@@ -221,6 +241,11 @@ func (d *Discovery) PublishDevice(device *domain.Device, profile *domain.Profile
 
 // UpdateSelectOptions updates the options for a select entity
 func (d *Discovery) UpdateSelectOptions(device *domain.Device, profile *domain.Profile, mapping domain.OIDMapping, options []string) error {
+	d.mu.RLock()
+	discoveryPrefix := d.discoveryPrefix
+	topicPrefix := d.topicPrefix
+	d.mu.RUnlock()
+
 	entityID := sanitizeEntityID(mapping.Name)
 	uniqueID := fmt.Sprintf("snmp_bridge_%s_%s", device.ID, entityID)
 	shortID := device.ID
@@ -239,19 +264,19 @@ func (d *Discovery) UpdateSelectOptions(device *domain.Device, profile *domain.P
 	}
 
 	config := &DiscoveryConfig{
-		Name:     mapping.Name,
-		UniqueID: uniqueID,
-		ObjectID: objectID,
-		Device:   haDevice,
-		AvailabilityTopic:   fmt.Sprintf("%s/bridge/status", d.topicPrefix),
+		Name:                mapping.Name,
+		UniqueID:            uniqueID,
+		ObjectID:            objectID,
+		Device:              haDevice,
+		AvailabilityTopic:   fmt.Sprintf("%s/bridge/status", topicPrefix),
 		PayloadAvailable:    "online",
 		PayloadNotAvailable: "offline",
-		StateTopic:          fmt.Sprintf("%s/%s/%s/state", d.topicPrefix, device.ID, entityID),
+		StateTopic:          fmt.Sprintf("%s/%s/%s/state", topicPrefix, device.ID, entityID),
 		Options:             options,
 	}
 
 	if mapping.Writable {
-		config.CommandTopic = fmt.Sprintf("%s/%s/%s/set", d.topicPrefix, device.ID, entityID)
+		config.CommandTopic = fmt.Sprintf("%s/%s/%s/set", topicPrefix, device.ID, entityID)
 	}
 
 	if mapping.Icon != "" {
@@ -259,7 +284,7 @@ func (d *Discovery) UpdateSelectOptions(device *domain.Device, profile *domain.P
 	}
 
 	topic := fmt.Sprintf("%s/%s/%s/%s/config",
-		d.discoveryPrefix,
+		discoveryPrefix,
 		componentToString(mapping.HAComponent),
 		device.ID,
 		entityID,
@@ -273,12 +298,15 @@ func (d *Discovery) RemoveDevice(deviceID string, profile *domain.Profile) error
 	if profile == nil {
 		return nil
 	}
+	d.mu.RLock()
+	discoveryPrefix := d.discoveryPrefix
+	d.mu.RUnlock()
 
 	for _, mapping := range profile.OIDMappings {
 		entityID := sanitizeEntityID(mapping.Name)
 
 		topic := fmt.Sprintf("%s/%s/%s/%s/config",
-			d.discoveryPrefix,
+			discoveryPrefix,
 			componentToString(mapping.HAComponent),
 			deviceID,
 			entityID,

--- a/internal/mqtt/publisher.go
+++ b/internal/mqtt/publisher.go
@@ -96,6 +96,38 @@ func (p *Publisher) Start() error {
 	return nil
 }
 
+// RefreshDiscovery republishes bridge and registered device discovery using the current MQTT config.
+func (p *Publisher) RefreshDiscovery() error {
+	if !p.client.IsConnected() {
+		return fmt.Errorf("not connected to MQTT broker")
+	}
+
+	cfg := p.client.GetConfig()
+	p.discovery.UpdatePrefixes(cfg.DiscoveryPrefix, cfg.TopicPrefix)
+
+	if err := p.discovery.PublishBridgeDiscovery(); err != nil {
+		return fmt.Errorf("failed to publish bridge discovery: %w", err)
+	}
+
+	p.devicesMu.RLock()
+	devices := make([]*deviceInfo, 0, len(p.devices))
+	for _, info := range p.devices {
+		devices = append(devices, info)
+	}
+	p.devicesMu.RUnlock()
+
+	for _, info := range devices {
+		if info == nil || info.profile == nil {
+			continue
+		}
+		if err := p.discovery.PublishDevice(info.device, info.profile); err != nil {
+			return fmt.Errorf("failed to publish discovery for device %s: %w", info.device.ID, err)
+		}
+	}
+
+	return nil
+}
+
 // Stop stops the publisher
 func (p *Publisher) Stop() {
 	p.cancel()
@@ -217,7 +249,7 @@ func (p *Publisher) publishState(event service.StateUpdateEvent) {
 			// For select entities showing "Selected Source" or "Preferred Source",
 			// replace generic names with actual source names
 			if mapping.HAComponent == domain.HAComponentSelect ||
-			   (mapping.Name == "Selected Source" || mapping.Name == "Preferred Source") {
+				(mapping.Name == "Selected Source" || mapping.Name == "Preferred Source") {
 				if hasSourceA && hasSourceB {
 					strVal := fmt.Sprintf("%v", publishValue)
 					if strVal == "Source A" || strVal == "1" {
@@ -551,8 +583,8 @@ func convertToSwitchValue(value interface{}) string {
 
 	// Map "on" values to ON
 	onValues := map[string]bool{
-		"on":  true,
-		"1":   true,
+		"on":   true,
+		"1":    true,
 		"true": true,
 	}
 

--- a/internal/mqtt/publisher_test.go
+++ b/internal/mqtt/publisher_test.go
@@ -1,10 +1,12 @@
 package mqtt
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	"snmp-mqtt-bridge/internal/config"
 	"snmp-mqtt-bridge/internal/domain"
 	"snmp-mqtt-bridge/internal/service"
 
@@ -81,6 +83,77 @@ func TestPublisher_RegisterUnregisterDevice(t *testing.T) {
 
 	if exists {
 		t.Error("Expected device to be unregistered")
+	}
+}
+
+func TestPublisher_RefreshDiscoveryUsesCurrentMQTTConfig(t *testing.T) {
+	mockMqtt := &mockMqttClient{connected: true}
+	client := &Client{
+		cfg: &config.MQTTConfig{
+			TopicPrefix:     "new-prefix",
+			DiscoveryPrefix: "new-homeassistant",
+		},
+		client:      mockMqtt,
+		connected:   true,
+		topicPrefix: "new-prefix",
+		handlers:    make(map[string]CommandHandler),
+	}
+	discovery := NewDiscovery(client, "old-homeassistant", "old-prefix")
+
+	profile := &domain.Profile{
+		ID:           "profile1",
+		Manufacturer: "APC",
+		Model:        "ATS",
+		OIDMappings: []domain.OIDMapping{
+			{Name: "Preferred Source", OID: ".1.2.3.1", HAComponent: domain.HAComponentSelect, Writable: true},
+		},
+	}
+
+	profileRepo := &mockProfileRepo{
+		profiles: map[string]*domain.Profile{
+			"profile1": profile,
+		},
+	}
+
+	pub := NewPublisher(client, discovery, nil, profileRepo)
+	device := &domain.Device{
+		ID:        "dev1",
+		Name:      "Main ATS",
+		ProfileID: "profile1",
+		Enabled:   true,
+	}
+
+	if err := pub.RegisterDevice(device); err != nil {
+		t.Fatalf("RegisterDevice failed: %v", err)
+	}
+	mockMqtt.published = nil
+
+	if err := pub.RefreshDiscovery(); err != nil {
+		t.Fatalf("RefreshDiscovery failed: %v", err)
+	}
+
+	if len(mockMqtt.published) != 2 {
+		t.Fatalf("expected bridge and device discovery publishes, got %d", len(mockMqtt.published))
+	}
+	if mockMqtt.published[0].topic != "new-homeassistant/sensor/snmp_bridge/status/config" {
+		t.Fatalf("expected bridge discovery on new prefix, got %q", mockMqtt.published[0].topic)
+	}
+	if mockMqtt.published[1].topic != "new-homeassistant/select/dev1/preferred_source/config" {
+		t.Fatalf("expected device discovery on new prefix, got %q", mockMqtt.published[1].topic)
+	}
+
+	var payload DiscoveryConfig
+	if err := json.Unmarshal(mockMqtt.published[1].payload.([]byte), &payload); err != nil {
+		t.Fatalf("failed to unmarshal discovery payload: %v", err)
+	}
+	if payload.StateTopic != "new-prefix/dev1/preferred_source/state" {
+		t.Fatalf("expected state topic to use new prefix, got %q", payload.StateTopic)
+	}
+	if payload.CommandTopic != "new-prefix/dev1/preferred_source/set" {
+		t.Fatalf("expected command topic to use new prefix, got %q", payload.CommandTopic)
+	}
+	if payload.AvailabilityTopic != "new-prefix/bridge/status" {
+		t.Fatalf("expected availability topic to use new prefix, got %q", payload.AvailabilityTopic)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry the initial MQTT connection in the background so addon startup can recover when the broker is not ready yet
- refresh Home Assistant MQTT discovery after every successful MQTT connect/reconnect
- update discovery prefixes from the active MQTT config before republishing discovery
- keep one-shot MQTT connection tests from leaving retrying clients in the background
- add regression coverage for refreshed discovery topics and payloads

Closes #11.

## Context
In HA, the addon upgraded to 0.0.13, but after startup it did not connect to MQTT until manual reconnect. After reconnect, old entities remained because registered devices were not republished to Home Assistant discovery.

## Tests
- go test ./...
- git diff --check
