### PR TITLE
Bump Home Assistant addon version to 0.0.14

### DIFF
--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.13"
+version: "0.0.14"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Summary
- bump the Home Assistant addon manifest version to 0.0.14 for the MQTT reconnect discovery fix

## Tests
- go test ./...
- git diff --check
