### PR TITLE
Fix add-on MQTT startup and add release changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate app changelog
+        run: bash scripts/check-addon-changelog.sh
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,8 @@ func setDefaults(v *viper.Viper) {
 	// MQTT defaults
 	v.SetDefault("mqtt.broker", "localhost")
 	v.SetDefault("mqtt.port", 1883)
+	v.SetDefault("mqtt.username", "")
+	v.SetDefault("mqtt.password", "")
 	v.SetDefault("mqtt.client_id", "snmp-mqtt-bridge")
 	v.SetDefault("mqtt.topic_prefix", "snmp-bridge")
 	v.SetDefault("mqtt.discovery", true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,23 @@ func TestLoadMapsServerIngressPathEnv(t *testing.T) {
 	}
 }
 
+func TestLoadMapsMQTTCredentialsFromEnv(t *testing.T) {
+	t.Setenv("SNMP_BRIDGE_MQTT_USERNAME", "addon-user")
+	t.Setenv("SNMP_BRIDGE_MQTT_PASSWORD", "addon-password")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.MQTT.Username != "addon-user" {
+		t.Fatalf("MQTT.Username = %q, want %q", cfg.MQTT.Username, "addon-user")
+	}
+	if cfg.MQTT.Password != "addon-password" {
+		t.Fatalf("MQTT.Password = %q, want %q", cfg.MQTT.Password, "addon-password")
+	}
+}
+
 func TestDatabaseConfigGetDSN(t *testing.T) {
 	tests := []struct {
 		name string

--- a/scripts/check-addon-changelog.sh
+++ b/scripts/check-addon-changelog.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="snmp-mqtt-bridge/config.yaml"
+changelog="snmp-mqtt-bridge/CHANGELOG.md"
+
+version=$(sed -n 's/^version: *"\([^"]*\)".*/\1/p' "${manifest}")
+if [[ -z "${version}" ]]; then
+    echo "Unable to read app version from ${manifest}" >&2
+    exit 1
+fi
+
+version_pattern=${version//./\\.}
+if ! grep -Eq "^## \\[?${version_pattern}\\]?([[:space:]]|$)" "${changelog}"; then
+    echo "Missing changelog entry for app version ${version}" >&2
+    exit 1
+fi
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+    tag_version=${GITHUB_REF_NAME#v}
+    if [[ "${tag_version}" != "${version}" ]]; then
+        echo "Tag ${GITHUB_REF_NAME} does not match app version ${version}" >&2
+        exit 1
+    fi
+fi
+
+echo "Changelog contains app version ${version}"

--- a/snmp-mqtt-bridge/CHANGELOG.md
+++ b/snmp-mqtt-bridge/CHANGELOG.md
@@ -1,0 +1,137 @@
+# Changelog
+
+All notable changes to the SNMP-MQTT Bridge Home Assistant app are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- Load MQTT username and password from Home Assistant app options during startup, so automatic reconnects authenticate correctly after an update or restart.
+
+### Added
+
+- Validate in CI that the app version has a matching changelog entry.
+
+## [0.0.16] - 2026-07-15
+
+### Added
+
+- Redesigned the dashboard with live availability, outlet, current, power, and device summaries.
+- Added MQTT connection status and a persistent Safe Mode for device control confirmations.
+- Added device search, inline enable controls, device icons, and live status summaries.
+
+### Fixed
+
+- Prevent MQTT connection attempts and frontend requests from hanging indefinitely during broker outages.
+- Restore command subscriptions and Home Assistant discovery after MQTT reconnects.
+
+## [0.0.15] - 2026-07-04
+
+### Fixed
+
+- Normalize temperature units in Home Assistant MQTT discovery payloads.
+
+## [0.0.14] - 2026-06-18
+
+### Fixed
+
+- Republish Home Assistant discovery after MQTT settings are changed or the connection is restored.
+
+## [0.0.13] - 2026-06-18
+
+### Fixed
+
+- Keep MQTT discovery and command subscriptions synchronized when devices are added, updated, enabled, disabled, or removed.
+
+## [0.0.12] - 2026-06-10
+
+### Added
+
+- Added Home Assistant app icon and logo assets.
+- Expanded MQTT command handling test coverage.
+
+### Fixed
+
+- Match SNMP traps to devices configured with hostnames.
+- Bind the Home Assistant ingress path correctly from the app environment.
+
+## [0.0.11] - 2026-06-09
+
+### Fixed
+
+- Reject failed SNMP SET responses instead of reporting outlet commands as successful.
+
+## [0.0.10] - 2026-06-09
+
+### Fixed
+
+- Handle profile-specific outlet state values and ATEN outlet control settings.
+
+## [0.0.9] - 2026-05-27
+
+### Added
+
+- Added the ATEN PE8108G eco PDU profile with outlet control and per-outlet energy counters.
+
+### Changed
+
+- Refined device details, profile selection, status badges, and the dark frontend theme.
+
+### Fixed
+
+- Serialize WebSocket writes and improve local device state display.
+
+## [0.0.8] - 2026-03-23
+
+### Added
+
+- Publish bridge self-discovery to Home Assistant.
+
+### Fixed
+
+- Reflect MQTT credentials supplied by Home Assistant in the settings interface.
+- Format PostgreSQL connection ports correctly.
+
+## [0.0.7] - 2026-02-01
+
+### Fixed
+
+- Use relative frontend asset paths for Home Assistant ingress compatibility.
+
+## [0.0.6] - 2026-02-01
+
+### Fixed
+
+- Use a pure-Go SQLite driver for CGO-free builds.
+
+## [0.0.5] - 2026-02-01
+
+### Fixed
+
+- Publish Home Assistant app container packages as public images.
+
+## [0.0.4] - 2026-02-01
+
+### Fixed
+
+- Correct the Home Assistant app image path format.
+
+## [0.0.3] - 2026-02-01
+
+### Added
+
+- Added the Home Assistant app with ingress and Bashio-based MQTT service integration.
+
+## [0.0.2] - 2026-02-01
+
+### Added
+
+- Added Energenie EG-PDU-003 support with outlet control, power metrics, and Home Assistant entities.
+
+## [0.0.1] - 2026-02-01
+
+### Added
+
+- Initial release with APC ATS and PDU profiles, SNMP polling, traps, MQTT, and Home Assistant discovery.


### PR DESCRIPTION
## Summary

- load MQTT username and password from Home Assistant app environment variables during process startup
- add regression coverage for Bashio-provided MQTT credentials
- add the Home Assistant app changelog for releases 0.0.1 through 0.0.16
- validate manifest/changelog version consistency in CI and tagged releases

## Root cause

The app options contained valid MQTT credentials, but Viper did not include `mqtt.username` and `mqtt.password` during `Unmarshal` because those keys had no defaults or explicit bindings. The bridge therefore retried with empty credentials after an app update. Manual reconnect worked because that path loaded credentials from SQLite.

Live verification on Home Assistant showed Mosquitto rejecting the startup client with a null username. Calling the existing reconnect endpoint immediately restored the connection to the same broker, confirming that networking and Mosquitto were healthy.

## Validation

- `go test ./...`
- `go test -race ./internal/config ./internal/mqtt`
- `npm run build`
- `bash scripts/check-addon-changelog.sh`
- negative tag/version mismatch check
- live MQTT status after reconnect: connected

Closes #7
