### PR TITLE
Release add-on version 0.0.17

### DIFF
--- a/snmp-mqtt-bridge/CHANGELOG.md
+++ b/snmp-mqtt-bridge/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.17] - 2026-07-15
+
 ### Fixed
 
 - Load MQTT username and password from Home Assistant app options during startup, so automatic reconnects authenticate correctly after an update or restart.

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.16"
+version: "0.0.17"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Summary

- bump the Home Assistant app manifest to `0.0.17`
- finalize the `0.0.17` changelog entry for authenticated MQTT startup and changelog validation

## Validation

- `bash scripts/check-addon-changelog.sh`
- `go test ./...`
- `git diff --check`
