### PR TITLE
Show ATS sources and the actual app version

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -104,6 +104,22 @@ function buildDeviceView(device) {
     : selectedSource === 2 || selectedSource === '2' || selectedSource === 'Source B' || selectedSource === sourceBName
       ? sourceBName
       : cleanText(selectedSource, 'Unknown')
+  const sources = [
+    {
+      id: 'A',
+      name: sourceAName,
+      voltage: formatNumber(firstNumber(values, ['Source A Voltage']), 1, 'V'),
+      status: cleanText(values['Source A Status'], 'Unknown'),
+      active: activeSource === sourceAName,
+    },
+    {
+      id: 'B',
+      name: sourceBName,
+      voltage: formatNumber(firstNumber(values, ['Source B Voltage']), 1, 'V'),
+      status: cleanText(values['Source B Status'], 'Unknown'),
+      active: activeSource === sourceBName,
+    },
+  ]
 
   let metrics = []
   if (category === 'pdu') {
@@ -132,6 +148,7 @@ function buildDeviceView(device) {
     profile,
     category,
     outlets,
+    sources,
     metrics,
     current,
     power,
@@ -251,6 +268,24 @@ function formatLastPoll(value) {
                 :title="`${outlet.number}. ${outlet.name}: ${outlet.on ? 'On' : 'Off'}`"
               >{{ outlet.number }}</span>
               <em v-if="device.outlets.length === 0">No outlet data</em>
+            </div>
+          </div>
+          <div v-else-if="device.category === 'ats'" class="source-summary">
+            <span class="source-summary-label">Sources</span>
+            <div class="source-list">
+              <div
+                v-for="source in device.sources"
+                :key="source.id"
+                class="source-pill"
+                :class="{ active: device.state?.online && source.active, offline: !device.state?.online }"
+                :title="`${source.name}: ${source.voltage}, ${source.status}`"
+              >
+                <span>{{ source.id }}</span>
+                <div>
+                  <strong>{{ source.name }}</strong>
+                  <small>{{ device.state?.online ? `${source.voltage} · ${source.status}` : 'Offline' }}</small>
+                </div>
+              </div>
             </div>
           </div>
           <div v-else class="device-poll">
@@ -487,7 +522,8 @@ function formatLastPoll(value) {
 
 .device-metrics span,
 .device-poll span,
-.outlet-summary-label {
+.outlet-summary-label,
+.source-summary-label {
   display: block;
   color: var(--ui-muted);
   font-size: 10px;
@@ -540,6 +576,71 @@ function formatLastPoll(value) {
   font-style: normal;
 }
 
+.source-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: 7px;
+}
+
+.source-pill {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  padding: 6px 7px;
+  border: 1px solid var(--ui-border-strong);
+  border-radius: 8px;
+  background: var(--ui-bg-soft);
+}
+
+.source-pill > span {
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  color: var(--ui-muted);
+  background: var(--ui-panel);
+  font-size: 9px;
+  font-weight: 900;
+}
+
+.source-pill strong,
+.source-pill small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-pill strong {
+  color: var(--ui-text);
+  font-size: 10px;
+}
+
+.source-pill small {
+  margin-top: 1px;
+  color: var(--ui-muted);
+  font-size: 9px;
+}
+
+.source-pill.active {
+  border-color: color-mix(in srgb, var(--ui-success) 48%, var(--ui-border));
+  background: var(--ui-success-soft);
+  box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--ui-success) 24%, transparent);
+}
+
+.source-pill.active > span {
+  color: var(--ui-success);
+  background: color-mix(in srgb, var(--ui-success) 13%, var(--ui-panel));
+}
+
+.source-pill.offline {
+  opacity: 0.58;
+}
+
 .device-chevron {
   width: 18px;
   color: var(--ui-muted);
@@ -586,6 +687,7 @@ function formatLastPoll(value) {
 
   .device-metrics,
   .outlet-summary,
+  .source-summary,
   .device-poll {
     grid-column: 1;
   }

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -9,6 +9,7 @@ const mqttStatus = ref({ connected: false, broker: '' })
 const reconnecting = ref(false)
 const testing = ref(false)
 const testResult = ref(null)
+const appVersion = __APP_VERSION__
 
 const formFields = [
   { key: 'mqtt.broker', label: 'MQTT Broker', type: 'text', placeholder: 'localhost' },
@@ -194,7 +195,7 @@ async function testMQTTConnection() {
       <dl class="space-y-2">
         <div class="flex justify-between">
           <dt class="text-gray-500">Version</dt>
-          <dd>1.0.0</dd>
+          <dd>{{ appVersion }}</dd>
         </div>
         <div class="flex justify-between">
           <dt class="text-gray-500">API</dt>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { readFileSync } from 'node:fs'
+
+const addonManifest = readFileSync(new URL('../snmp-mqtt-bridge/config.yaml', import.meta.url), 'utf8')
+const addonVersion = addonManifest.match(/^version:\s*["']?([^"'\s]+)["']?/m)?.[1] || 'dev'
 
 export default defineConfig({
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(addonVersion),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary

- replace the hardcoded `1.0.0` in Settings with the version read from the Home Assistant app manifest at frontend build time
- replace the ATS `Last update` column with Source A and Source B summaries
- show each source name, voltage and status, with the active source highlighted
- retain a compact offline state and responsive dashboard layout

## Validation

- `npm run build`
- `go test ./...`
- `git diff --check`
- verified the production bundle contains the manifest version and ATS source fields
