### PR TITLE
Release add-on version 0.0.18

### DIFF
--- a/snmp-mqtt-bridge/CHANGELOG.md
+++ b/snmp-mqtt-bridge/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.0.18] - 2026-07-15
+
+### Changed
+
+- Show both ATS sources with their names, voltages and statuses on the dashboard, highlighting the active source.
+
+### Fixed
+
+- Display the actual Home Assistant app version in Settings instead of a hardcoded value.
+
 ## [0.0.17] - 2026-07-15
 
 ### Fixed

--- a/snmp-mqtt-bridge/config.yaml
+++ b/snmp-mqtt-bridge/config.yaml
@@ -1,6 +1,6 @@
 name: "SNMP-MQTT Bridge"
 description: "Bridge SNMP devices (UPS, ATS, PDU) to Home Assistant via MQTT with auto-discovery"
-version: "0.0.17"
+version: "0.0.18"
 slug: snmp-mqtt-bridge
 url: "https://github.com/SPDG/snmp-mqtt-bridge"
 image: "ghcr.io/spdg/snmp-mqtt-bridge/{arch}"


### PR DESCRIPTION
## Summary

- bump the Home Assistant app manifest to `0.0.18`
- add release notes for the ATS source overview and dynamic Settings version

## Validation

- `npm run build`
- verified the production bundle contains `0.0.18`
- `bash scripts/check-addon-changelog.sh`
- tag/version validation for `v0.0.18`
- `go test ./...`
- `git diff --check`
